### PR TITLE
MarrytingButton 컴포넌트 수정

### DIFF
--- a/app/src/main/java/com/marryting/app/component/MarrytingButton.kt
+++ b/app/src/main/java/com/marryting/app/component/MarrytingButton.kt
@@ -1,0 +1,136 @@
+package com.marryting.app.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.marryting.app.R
+import com.ui.theme.EnglishTypography
+
+fun Modifier.noRippleClickable(interactionSource: MutableInteractionSource, enabled: Boolean, onClick: () -> Unit): Modifier = clickable(
+    indication = null,
+    interactionSource = interactionSource,
+    enabled = enabled,
+    onClick = onClick
+)
+
+@Composable
+fun MarrytingButton(modifier: Modifier = Modifier, text: String = "", enabled: Boolean = false, buttonType: MarrytingButtonType, onClick: () -> Unit) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val colorSet = if (!enabled && buttonType is MarrytingButtonType.RightArrow) {
+        buttonType.disabledColorSet
+    } else if (isPressed) {
+        buttonType.pressedColorSet
+    } else {
+        buttonType.activeColorSet
+    }
+
+    Row(
+        modifier = modifier
+            .background(colorSet.backgroundColor, RoundedCornerShape(40.dp))
+            .noRippleClickable(
+                interactionSource = interactionSource,
+                enabled = enabled,
+                onClick = onClick
+            )
+            .padding(vertical = 8.dp)
+            .padding(buttonType.contentPaddingValues),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (buttonType is MarrytingButtonType.LeftArrow) {
+            MarrytingButtonArrow(buttonType = buttonType, colorSet = colorSet)
+        }
+
+        Text(
+            text = text,
+            color = colorSet.contentColor,
+            style = EnglishTypography.subtitle1
+        )
+
+        if (buttonType is MarrytingButtonType.RightArrow) {
+            MarrytingButtonArrow(
+                modifier = Modifier.padding(start = 22.dp),
+                buttonType = buttonType,
+                colorSet = colorSet
+            )
+        }
+    }
+}
+
+@Composable
+private fun MarrytingButtonArrow(modifier: Modifier = Modifier, buttonType: MarrytingButtonType, colorSet: MarrytingButtonColorSet) {
+    val painter: Int = if (buttonType is MarrytingButtonType.LeftArrow) {
+        R.drawable.ic_arrow_left
+    } else {
+        R.drawable.ic_arrow_right
+    }
+
+    val circleColor = if (buttonType is MarrytingButtonType.LeftArrow) {
+        colorSet.backgroundColor
+    } else {
+        colorSet.contentColor
+    }
+
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .background(circleColor, RoundedCornerShape(40.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = painterResource(id = painter),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color = colorSet.arrowColor)
+        )
+    }
+}
+
+@Composable
+fun MarrytingIconButton(modifier: Modifier = Modifier, enabled: Boolean = true, buttonType: MarrytingButtonType, onClick: () -> Unit, @DrawableRes drawableRes: Int) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val colorSet = if (!enabled && buttonType is MarrytingButtonType.Icon) {
+        buttonType.disabledColorSet
+    } else if (isPressed) {
+        buttonType.pressedColorSet
+    } else {
+        buttonType.activeColorSet
+    }
+
+    Box(
+        modifier = modifier
+            .size(48.dp)
+            .background(colorSet.backgroundColor, RoundedCornerShape(30.dp))
+            .noRippleClickable(
+                interactionSource = interactionSource,
+                enabled = enabled,
+                onClick = onClick
+            )
+            .padding(buttonType.contentPaddingValues)
+    ) {
+        Icon(
+            modifier = Modifier.align(Alignment.Center),
+            painter = painterResource(id = drawableRes),
+            contentDescription = null,
+            tint = colorSet.contentColor
+        )
+    }
+}

--- a/app/src/main/java/com/marryting/app/component/MarrytingButtonType.kt
+++ b/app/src/main/java/com/marryting/app/component/MarrytingButtonType.kt
@@ -1,89 +1,39 @@
 package com.marryting.app.component
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.marryting.app.R
 import com.ui.theme.DarkColor
 
-@Composable
-fun MarrytingButton(modifier: Modifier = Modifier, text: String = "", enabled: Boolean = false, buttonType: MarrytingButtonType, onClick: () -> Unit) {
-    Button(
-        modifier = modifier,
-        enabled = enabled,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = buttonType.backgroundAndArrowColor,
-            disabledContainerColor = DarkColor.Grey300,
-            disabledContentColor = DarkColor.Grey200
-        ),
-        onClick = { onClick() }
-    ) {
-        if (buttonType is MarrytingButtonType.LeftArrow) {
-            MarrytingButtonArrow(buttonType = buttonType)
-        }
-
-        Text(
-            text = text,
-            modifier = Modifier.padding(buttonType.paddingValues),
-            color = buttonType.textAndCircleColor
-        )
-
-        if (buttonType is MarrytingButtonType.RightArrow) {
-            MarrytingButtonArrow(buttonType = buttonType)
-        }
-    }
-}
-
-@Composable
-private fun MarrytingButtonArrow(buttonType: MarrytingButtonType) {
-    Box(
-        modifier = Modifier
-            .size(40.dp)
-            .background(buttonType.textAndCircleColor, RoundedCornerShape(40.dp)),
-        contentAlignment = Alignment.Center
-    ) {
-        val painter: Int = if (buttonType is MarrytingButtonType.LeftArrow) {
-            R.drawable.ic_arrow_left
-        } else {
-            R.drawable.ic_arrow_right
-        }
-
-        Image(
-            painter = painterResource(id = painter),
-            contentDescription = "",
-            colorFilter = ColorFilter.tint(color = buttonType.backgroundAndArrowColor)
-        )
-    }
-}
+data class MarrytingButtonColorSet(
+    val contentColor: Color,
+    val backgroundColor: Color,
+    val arrowColor: Color = backgroundColor
+)
 
 sealed class MarrytingButtonType(
-    open val textAndCircleColor: Color, // 텍스트, 원 동일
-    open val backgroundAndArrowColor: Color, // 백그라운드 화살표 동일
-    open val paddingValues: PaddingValues
+    open val activeColorSet: MarrytingButtonColorSet,
+    open val pressedColorSet: MarrytingButtonColorSet,
+    open val disabledColorSet: MarrytingButtonColorSet?,
+    open val contentPaddingValues: PaddingValues
 ) {
     data class LeftArrow(
-        override val textAndCircleColor: Color,
-        override val backgroundAndArrowColor: Color,
-        override val paddingValues: PaddingValues = PaddingValues(start = 22.dp)
-    ) : MarrytingButtonType(textAndCircleColor, backgroundAndArrowColor, paddingValues)
+        override val activeColorSet: MarrytingButtonColorSet,
+        override val pressedColorSet: MarrytingButtonColorSet,
+        override val contentPaddingValues: PaddingValues = PaddingValues(start = 8.dp, end = 24.dp)
+    ) : MarrytingButtonType(activeColorSet, pressedColorSet, null, contentPaddingValues)
 
     data class RightArrow(
-        override val textAndCircleColor: Color,
-        override val backgroundAndArrowColor: Color,
-        override val paddingValues: PaddingValues = PaddingValues(end = 22.dp)
-    ) : MarrytingButtonType(textAndCircleColor, backgroundAndArrowColor, paddingValues)
+        override val activeColorSet: MarrytingButtonColorSet,
+        override val pressedColorSet: MarrytingButtonColorSet,
+        override val disabledColorSet: MarrytingButtonColorSet,
+        override val contentPaddingValues: PaddingValues = PaddingValues(start = 36.dp, end = 8.dp)
+    ) : MarrytingButtonType(activeColorSet, pressedColorSet, disabledColorSet, contentPaddingValues)
+
+    data class Icon(
+        override val activeColorSet: MarrytingButtonColorSet,
+        override val pressedColorSet: MarrytingButtonColorSet,
+        override val disabledColorSet: MarrytingButtonColorSet = MarrytingButtonColorSet(contentColor = DarkColor.Grey200, backgroundColor = DarkColor.Grey700),
+        override val contentPaddingValues: PaddingValues
+    ) : MarrytingButtonType(activeColorSet, pressedColorSet, disabledColorSet, contentPaddingValues)
 }

--- a/app/src/main/java/com/marryting/app/presentation/empty/EmptyScreen.kt
+++ b/app/src/main/java/com/marryting/app/presentation/empty/EmptyScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.marryting.app.R
 import com.marryting.app.component.MarrytingButton
+import com.marryting.app.component.MarrytingButtonColorSet
 import com.marryting.app.component.MarrytingButtonType
 import com.ui.theme.Color
+import com.ui.theme.DarkColor
 import com.ui.theme.LightColor
 
 @Composable
@@ -49,14 +51,25 @@ fun EmptyScreen() {
                         .width(176.dp)
                         .align(Alignment.CenterHorizontally)
                         .padding(bottom = 40.dp, top = 10.dp),
-                    buttonType = MarrytingButtonType.RightArrow(
-                        textAndCircleColor = Color.White,
-                        backgroundAndArrowColor = LightColor.Grey800
-                    ),
                     text = "SHARE",
-                    enabled = true
-                ) {
-                }
+                    enabled = true,
+                    buttonType = MarrytingButtonType.RightArrow(
+                        activeColorSet = MarrytingButtonColorSet(
+                            contentColor = Color.White,
+                            backgroundColor = DarkColor.Grey800,
+                            arrowColor = Color.Black
+                        ),
+                        pressedColorSet = MarrytingButtonColorSet(
+                            contentColor = Color.White,
+                            backgroundColor = LightColor.Main300
+                        ),
+                        disabledColorSet = MarrytingButtonColorSet(
+                            contentColor = LightColor.Grey200,
+                            backgroundColor = LightColor.Grey300
+                        )
+                    ),
+                    onClick = { }
+                )
             }
         }
     }

--- a/app/src/main/java/com/marryting/app/presentation/profile/RegisterContentsScreen.kt
+++ b/app/src/main/java/com/marryting/app/presentation/profile/RegisterContentsScreen.kt
@@ -1,9 +1,9 @@
 package com.marryting.app.presentation.profile
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.marryting.app.component.MarrytingButton
+import com.marryting.app.component.MarrytingButtonColorSet
 import com.marryting.app.component.MarrytingButtonType
 import com.marryting.app.data.profile.ContentViewType
 import com.marryting.app.presentation.picture.GalleryScreen
@@ -43,16 +44,6 @@ fun RegisterContentsScreen(contents: RegisterState.Contents, onDonePressed: () -
                 currentContentIndex = contents.currentContentIndex
             )
         },
-        content = {
-            when (currentContentState.registerContent.contentViewType) {
-                ContentViewType.Pictures -> {
-                    GalleryScreen(
-                        modifier = Modifier
-                            .padding(it)
-                    )
-                }
-            }
-        },
         bottomBar = {
             RegisterBottomBar(
                 contentState = currentContentState,
@@ -61,7 +52,13 @@ fun RegisterContentsScreen(contents: RegisterState.Contents, onDonePressed: () -
                 onDonePressed = onDonePressed
             )
         }
-    )
+    ) { paddingValues ->
+        when (currentContentState.registerContent.contentViewType) {
+            ContentViewType.Pictures -> {
+                GalleryScreen(modifier = Modifier.padding(top = paddingValues.calculateTopPadding()))
+            }
+        }
+    }
 }
 
 @Composable
@@ -76,9 +73,11 @@ private fun RegisterTopBar(contentState: RegisterContentState, currentContentInd
             currentContentIndex = currentContentIndex,
             totalContentsCount = contentState.totalContentsCount
         )
-        Column(modifier = Modifier.padding(top = 16.dp)) {
+        Column(
+            modifier = Modifier.padding(top = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
             RegisterContentTitle(title = contentState.registerContent.title)
-            Spacer(modifier = Modifier.padding(4.dp))
             RegisterContentDescription(description = contentState.registerContent.description)
         }
     }
@@ -87,7 +86,7 @@ private fun RegisterTopBar(contentState: RegisterContentState, currentContentInd
 @Composable
 private fun RegisterBottomBar(contentState: RegisterContentState, onPreviousPressed: () -> Unit, onNextPressed: () -> Unit, onDonePressed: () -> Unit) {
     Surface(
-        color = Color.DarkBackground,
+        color = androidx.compose.ui.graphics.Color.Transparent,
         modifier = Modifier
             .fillMaxWidth()
             .padding(bottom = 40.dp, start = 32.dp, end = 32.dp)
@@ -98,38 +97,61 @@ private fun RegisterBottomBar(contentState: RegisterContentState, onPreviousPres
             if (contentState.showPrevious) {
                 MarrytingButton(
                     modifier = Modifier.padding(end = 22.dp),
-                    text = "PREV",
+                    text = "PRE",
                     enabled = true,
                     buttonType = MarrytingButtonType.LeftArrow(
-                        DarkColor.Grey700,
-                        DarkColor.Grey200
+                        activeColorSet = MarrytingButtonColorSet(
+                            contentColor = DarkColor.Grey200,
+                            backgroundColor = DarkColor.Grey700
+                        ),
+                        pressedColorSet = MarrytingButtonColorSet(
+                            contentColor = Color.White,
+                            backgroundColor = DarkColor.Grey600
+                        )
                     ),
                     onClick = onPreviousPressed
                 )
             }
             if (contentState.showDone) {
-                MarrytingButton(
+                NextAndDoneButton(
                     modifier = Modifier.align(Alignment.CenterEnd),
                     text = "DONE",
                     enabled = contentState.enabledNext,
-                    buttonType = MarrytingButtonType.RightArrow(
-                        DarkColor.Grey800,
-                        DarkColor.SubGreen
-                    ),
                     onClick = onDonePressed
                 )
             } else {
-                MarrytingButton(
+                NextAndDoneButton(
                     modifier = Modifier.align(Alignment.CenterEnd),
                     text = "NEXT",
                     enabled = contentState.enabledNext,
-                    buttonType = MarrytingButtonType.RightArrow(
-                        DarkColor.Grey800,
-                        DarkColor.SubGreen
-                    ),
                     onClick = onNextPressed
                 )
             }
         }
     }
+}
+
+@Composable
+private fun NextAndDoneButton(modifier: Modifier = Modifier, text: String, enabled: Boolean, onClick: () -> Unit) {
+    MarrytingButton(
+        modifier = modifier,
+        text = text,
+        enabled = enabled,
+        buttonType = MarrytingButtonType.RightArrow(
+            activeColorSet = MarrytingButtonColorSet(
+                contentColor = DarkColor.Grey800,
+                backgroundColor = DarkColor.SubGreen,
+                arrowColor = Color.White
+            ),
+            pressedColorSet = MarrytingButtonColorSet(
+                contentColor = Color.White,
+                backgroundColor = DarkColor.SubGreen
+            ),
+            disabledColorSet = MarrytingButtonColorSet(
+                contentColor = DarkColor.Grey200,
+                backgroundColor = DarkColor.Grey300
+            )
+        ),
+        onClick = onClick
+    )
 }


### PR DESCRIPTION
./gradlew spotlessApply 를 사용하여 코드 정리 확인해주세요.

### Overview
- MarrytingButtonType 구조 변경
- MarrytingIconButton 추가
- Button 클릭 시 리플 효과 제거되도록 설정

### 참고 사항
1. 한 버튼에 active, pressed, disabled 상태에 따라 색상이 다르게 지정되어 있어서 `MarrytingButtonType`의 구조를 변경했어요!
- `MarrytingButtonColorSet`에 content, background, arrow 색상이 들어가고, active일 때만 arrow 색상이 따로 지정돼서 기본 값으로 background 색상을 넣어놨어요
- LeftArrow는 text와 circle 색상이 다르고 RightArrow는 같아서, contentColor를 text와 circle 색상으로 분리할까..라고도 생각했지만 분리하지 않고
- `MarrytingButtonArrow`에서 circleColor를 LeftArrow와 RightArrow에 따라 다르게 설정되도록 분기 처리했어요
- `MarrytingButton`뿐만 아니라 `MarrytingIconButton`에도 `MarrytingButtonType`을 적용하면 좋을 거 같아서 `Icon` data class도 추가했습니다
2. Button 클릭 시 리플 효과를 제거하기 위해 `fun Modifier.noRippleClickable()`를 추가했어요
- modifier에 적용하는 거라 Button을 Row와 Box로 수정했슴다
- 이 버튼들 외로 keyword, radio group 등에도 적용 예정!

혹시 더 나은 방법이 있다면 말해주세용ㅎㅎ

### `MarrytingIconButton` 사용 방법
- buttonType을 MarrytingButtonType.Icon으로 설정 + activeColorSet, pressedColorSet 추가
- contentPaddingValues에 Icon마다 8 or 12로 다르게 설정되어 있는 패딩값 추가
- drawableRes에 Icon drawble 추가
 ```kotlin
@Preview
@Composable
fun MarrytingIconButtonPreview() {
    MarrytingIconButton(
        enabled = true,
        buttonType = MarrytingButtonType.Icon(
            activeColorSet = MarrytingButtonColorSet(
                contentColor = com.ui.theme.Color.White,
                backgroundColor = LightColor.Grey800
            ),
            pressedColorSet = MarrytingButtonColorSet(
                contentColor = com.ui.theme.Color.White,
                backgroundColor = LightColor.Main300
            ),
            contentPaddingValues = PaddingValues(12.dp)
        ),
        onClick = { },
        drawableRes = R.drawable.ic_arrow_right
    )
}
```

